### PR TITLE
role.txt: fix a typo for "gbraad.docker-registry"

### DIFF
--- a/roles.txt
+++ b/roles.txt
@@ -1,5 +1,5 @@
 gbraad.docker
-gbraad.docker-regsitry
+gbraad.docker-registry
 gbraad.kubernetes-master
 gbraad.kubernetes-node
 gbraad.kubernetes-client


### PR DESCRIPTION
The typo make ansible-playbook process fail.
Signed-off-by: Weibing Zhang zhangweibing@unitedstack.com
